### PR TITLE
Revert "Install upstream binary, don't compile."

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: "Install Go"
+          command: |
+            curl -sSL "https://dl.google.com/go/go1.11.linux-amd64.tar.gz" | tar -xz -C /usr/local
+            echo 'export PATH=$PATH:/usr/local/go/bin' > $BASH_ENV
+      - run:
           name: "Build Snap"
           command: snapcraft
       - persist_to_workspace:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,9 +24,14 @@ parts:
     plugin: nil
     override-build: |
       snapcraftctl build
-      curl -sSL "https://github.com/github/hub/releases/download/v2.14.2/hub-linux-amd64-2.14.2.tgz" -o hub.tar.gz
-      tar xfz hub.tar.gz
-      cp hub-linux-amd64-2.14.2/bin/hub $SNAPCRAFT_PART_INSTALL
+      export GOPATH=$SNAPCRAFT_PART_INSTALL/go
+      export PATH=$GOPATH/bin:$PATH
+      mkdir -p $GOPATH/src/github.com/github/
+      cd $GOPATH/src/github.com/github/
+      git clone --branch=$SNAPCRAFT_PROJECT_VERSION https://github.com/github/hub.git
+      cd hub
+      CGO_ENABLED=0 go build -ldflags "-X github.com/github/hub/version.Version=`./script/version`"
+      cp hub $SNAPCRAFT_PART_INSTALL
     build-packages:
       - git
 apps:


### PR DESCRIPTION
Reverts felicianotech/hub-snap#32

I now remembered while I custom compiled in the first place. The binary produced upstream isn't a static binary. It has a few dependencies including libc and 3 others. As a class snap (this snap will pull libraries on the client system) a dynamic binary makes compatibility much more difficult.

I will revert back to custom compiling, update the Go version, and just pull the man pages from the official release rather than the binary.