### PR TITLE
Store and utilize man pages for hub help

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ In fact, it is suggested to alias `git` to run `hub` instead.
 Convenient commands such as `hub clone felicianotech/hub-snap` could be run instead of the longer `git clone git://github.com/felicianotech/hub-snap.git`.
 A full list of commands can be found in hub's [user manual](https://hub.github.com/hub.1.html).
 
+### Help Text / Man Pages
+
+To use help, run `hub help <topic>`.
+For example, if you want to learn about using pull requests with hub you would run:
+
+```bash
+hub help pull-request
+```
+
 
 ## Development
 
@@ -41,6 +50,15 @@ snapcraft snap
 Originally this snap was suppose to simply package the binaries already published by GitHub.
 Problem is, the binaries they make aren't statically linked which makes the snap world difficult.
 So instead, we're compiling `hub` based off the appropriate Git tag.
+
+
+## Changelog
+
+This is a changelog for the hub snap and not hub itself.
+
+- revision #43
+  - Starting with build 43 (containing hub v2.14.2) the internal help for the CLI works again.
+  - compiled with Go v1.14
 
 
 ## License

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,8 +35,16 @@ parts:
       cd hub
       CGO_ENABLED=0 go build -ldflags "-X github.com/github/hub/version.Version=`./script/version`"
       cp hub $SNAPCRAFT_PART_INSTALL
+
+      # Download the upstream release to get the man pages
+      curl -sSL "https://github.com/github/hub/releases/download/v`./script/version`/hub-linux-amd64-`./script/version`.tgz" -o hub.tar.gz
+      tar xfz hub.tar.gz
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/share/man/man1
+      cp hub-linux-amd64-`./script/version`/share/man/man1/*.1 $SNAPCRAFT_PART_INSTALL/usr/share/man/man1/
     build-packages:
       - git
 apps:
   hub:
     command: hub
+    environment:
+      MANPATH: "/snap/hub/current/usr/share/man:$MANPATH"


### PR DESCRIPTION
Fixes #25

hub switched the internal CLI help system to simply call man pages. This snap didn't use to install the man pages so help didn't work.

With this PR, the man pages are now installed and configured to work. Note, as this is a snap, the help text/man pages work with running `hub help`. They still won't work when running `man hub` as Linux snaps cannot currently do that.